### PR TITLE
select and reconfigure to WpaController

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,7 +765,7 @@ impl WpaController {
             Some(Ok(Ok(()))) => Ok(()),
             Some(Ok(Err(r))) => return Err(io::Error::new(io::ErrorKind::Other, format!("reconfigure ret={:?}", r))),
             Some(Err(error)) => return Err(error),
-            None => return Err(io::Error::new(io::ErrorKind::Other, format!("reconfigure completed"))),
+            None => return Err(io::Error::new(io::ErrorKind::Other, format!("reconfigure has no reply"))),
         }
     }
 }


### PR DESCRIPTION
I added implementation of a couple things I needed as two methods:

- WpaController::select_network() - selecting a network by Id
- WpaController::reconfigure() - wpa reconfigure

lmk if you'd like some modifications or prefer the PR formatted differently.  Thanks!