### PR TITLE
fix(lib): Correct typo in LOCAL_SOCKET_PREFIX to 'wpa_ctrl'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ compile_error!("Supports only unix targets");
 const LOCAL_SOCKET_DIR: &str = "/data/misc/wifi/sockets";
 #[cfg(not(target_os = "android"))]
 const LOCAL_SOCKET_DIR: &str = "/tmp";
-const LOCAL_SOCKET_PREFIX: &str = "wpa_crtl_";
+const LOCAL_SOCKET_PREFIX: &str = "wpa_ctrl_";
 const UNSOLICITED_PREFIX: char = '<';
 type LocalSocketName = str_buf::StrBuf<23>;
 


### PR DESCRIPTION
Corrects a spelling mistake in the `LOCAL_SOCKET_PREFIX` constant.

The prefix was incorrectly defined as "wpa_crtl_" instead of the correct "wpa_ctrl_".

This typo causes the library to create client socket files (e.g., /tmp/wpa_crtl_1) with an incorrect name.

As a result, external applications or cleanup scripts attempting to find and remove stale sockets (by looking for the correct "wpa_ctrl_" prefix) will fail. This leads to persistent "Address in use (os error 98)" errors on application restart, as the stale socket files are never deleted.